### PR TITLE
fix: Discord CSP

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,15 @@
     let discordHelper: DiscordHelper;
 
     onMount(() => {
+        if (window.location.hostname.includes("discordsays.com")) {
+            const originalFetch = window.fetch;
+
+            window.fetch = (input, init) => {
+                // Use the saved original fetch function inside the redefined one
+                return originalFetch(".proxy/" + input, init);
+            };
+        }
+
         discordHelper = new DiscordHelper();
         discordHelper.setupParentIframe();
         initializeUnity();


### PR DESCRIPTION
PR to Mirror https://github.com/TheSleepyKoala/Svelcordot/pull/2 changes.

> Hello,
> 
> Since Discord updated their CSP (https://discord.com/channels/613425648685547541/697138785317814292/1263180507777339442) it's no longer possible to just host the files. Therefore I added the automatic addition of ".proxy" for fetch requests, since Godot's generated JS files use fetch under the hood to load files like the .wasm file. Since this is only needed in proxy mode, I also enabled that feature just for the proxy by checking for the hostname.
> 
> Hope that helps :)
> Kind regards


Thanks @PrinzKenny1